### PR TITLE
fix cgo syntax error cgo.go

### DIFF
--- a/base/cgo/1/cgo.go
+++ b/base/cgo/1/cgo.go
@@ -22,7 +22,6 @@ int SayHello(blob* pblob) {
     return 0;
 }
 */
-
 import "C"
 import (
 	"fmt"


### PR DESCRIPTION
fix cgo syntax error